### PR TITLE
Granular IAM permissions

### DIFF
--- a/functions/source/onboarding/Makefile
+++ b/functions/source/onboarding/Makefile
@@ -16,6 +16,6 @@ build: clean
 	python3 -m venv build/$(FUNCTION)
 	. build/$(FUNCTION)/bin/activate; \
 	pip3 install  -r requirements.txt; \
-	cp -r "$$VIRTUAL_ENV"/lib/python3.8/site-packages/ build/
+	cp -r "$$VIRTUAL_ENV"/lib/ build/
 	cd build/site-packages; zip -g -r $(DIST_DIR)/$(FUNCTION).zip . -x "*__pycache__*"
 	rm -rf build

--- a/functions/source/register/Makefile
+++ b/functions/source/register/Makefile
@@ -16,6 +16,6 @@ build: clean
 	python3 -m venv build/$(FUNCTION)
 	. build/$(FUNCTION)/bin/activate; \
 	pip3 install  -r requirements.txt; \
-	cp -r "$$VIRTUAL_ENV"/lib/python3.8/site-packages/ build/
+	cp -r "$$VIRTUAL_ENV"/lib/ build/
 	cd build/site-packages; zip -g -r $(DIST_DIR)/$(FUNCTION).zip . -x "*__pycache__*"
 	rm -rf build

--- a/functions/source/stackset/Makefile
+++ b/functions/source/stackset/Makefile
@@ -16,6 +16,6 @@ build: clean
 	python3 -m venv build/$(FUNCTION)
 	. build/$(FUNCTION)/bin/activate; \
 	pip3 install  -r requirements.txt; \
-	cp -r "$$VIRTUAL_ENV"/lib/python3.8/site-packages/ build/
+	cp -r "$$VIRTUAL_ENV"/lib/ build/
 	cd build/site-packages; zip -g -r $(DIST_DIR)/$(FUNCTION).zip . -x "*__pycache__*"
 	rm -rf build

--- a/templates/control-tower-customization.template.yml
+++ b/templates/control-tower-customization.template.yml
@@ -107,7 +107,7 @@ Resources:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
       Path: /
       Policies:
         - PolicyName: lambda-copier
@@ -119,14 +119,14 @@ Resources:
                   - s3:GetObject
                   - s3:GetObjectTagging
                 Resource:
-                  - !Sub 'arn:aws:s3:::${QSS3BucketName}/${QSS3KeyPrefix}*'
+                  - !Sub 'arn:${AWS::Partition}:s3:::${QSS3BucketName}/${QSS3KeyPrefix}*'
               - Effect: Allow
                 Action:
                   - s3:PutObject
                   - s3:DeleteObject
                   - s3:PutObjectTagging
                 Resource:
-                  - !Sub 'arn:aws:s3:::${LambdaZipsBucket}/${QSS3KeyPrefix}*'
+                  - !Sub 'arn:${AWS::Partition}:s3:::${LambdaZipsBucket}/${QSS3KeyPrefix}*'
 
   CopyZipsFunction:
     Type: AWS::Lambda::Function
@@ -263,7 +263,7 @@ Resources:
             - iam:PassRole
             Resource: !Join [':', ['arn:aws:iam:', !Ref 'AWS::AccountId', 'role/service-role/AWSControlTowerStackSetRole' ]]
       ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
 
   NewRelicCredentials:
     Type: AWS::SecretsManager::Secret
@@ -367,7 +367,7 @@ Resources:
             - !Ref NewRelicStackSNS
             - !Ref NewRelicRegisterSNS
       ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
   
   NewRelicStackSetFunction:
     Type: AWS::Lambda::Function
@@ -443,7 +443,7 @@ Resources:
             Resource:
               Ref: NewRelicCredentials
       ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
   
   NewRelicRegisterFunction:
     Type: AWS::Lambda::Function

--- a/templates/control-tower-customization.template.yml
+++ b/templates/control-tower-customization.template.yml
@@ -479,7 +479,7 @@ Resources:
           eventSource:
           - controltower.amazonaws.com
         detail-type:
-        - AWS service event via AWS CloudTrail
+        - AWS Service Event via CloudTrail
         source:
         - aws.controltower
       Name: NewRelicControlTowerEvents

--- a/templates/newrelic-stack-set.yml
+++ b/templates/newrelic-stack-set.yml
@@ -71,7 +71,7 @@ Resources:
                 'sts:ExternalId': !Ref NewRelicAccountNumber
 
 # Policy reference from: https://docs.newrelic.com/docs/integrations/amazon-integrations/get-started/integrations-managed-policies/#list-permissions                
-  NewRelicCustomPolicy:
+  NewRelicCustomPolicyGranular:
     Type: 'AWS::IAM::ManagedPolicy'
     Metadata:
       cfn_nag:
@@ -82,60 +82,28 @@ Resources:
             reason: "New Relic requires permission to read telemetry data from all AWS resources in your account."
           - id: W28
             reason: "New Relic must use unique IAM role names to identify them."
-#      cfn-lint:
-#        config:
-#          ignore_checks:
-            # TrustedAdvisor access at the moment requires permission wildcard `support:*`
-            #- EIAMPolicyActionWildcard
     Condition: UseCustomPolicy
     Properties:    
-      ManagedPolicyName: !Ref PolicyName
+      ManagedPolicyName: !Join ['-', [!Ref PolicyName, 'GranularResources']]
       Roles:
         - !Ref NewRelicCustomPolicyRole
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          - Effect: Allow
-            Action:      
-              - 'elasticloadbalancing:DescribeLoadBalancers'
-              - 'elasticloadbalancing:DescribeTargetGroups'
-              - 'elasticloadbalancing:DescribeTags'
-              - 'elasticloadbalancing:DescribeLoadBalancerAttributes'
-              - 'elasticloadbalancing:DescribeListeners'              
-              - 'elasticloadbalancing:DescribeRules'
-              - 'elasticloadbalancing:DescribeTargetGroupAttributes'              
-              - 'elasticloadbalancing:DescribeInstanceHealth'              
-              - 'elasticloadbalancing:DescribeLoadBalancerPolicies'
-              - 'elasticloadbalancing:DescribeLoadBalancerPolicyTypes'
+          - Sid: Integration1
+            Effect: Allow
+            Action:    
               - 'apigateway:GET'
               - 'apigateway:HEAD'
               - 'apigateway:OPTIONS'
-              - 'autoscaling:DescribeLaunchConfigurations'
-              - 'autoscaling:DescribeAutoScalingGroups'
-              - 'autoscaling:DescribePolicies'
-              - 'autoscaling:DescribeTags'
-              - 'autoscaling:DescribeAccountLimits'
               - 'budgets:ViewBudget'
-              - 'cloudfront:ListDistributions'
-              - 'cloudfront:ListStreamingDistributions'
               - 'cloudfront:ListTagsForResource'
-              - 'cloudtrail:LookupEvents'
-              - 'dynamodb:DescribeLimits'
-              - 'dynamodb:ListTables'
               - 'dynamodb:DescribeTable'
-              - 'dynamodb:ListGlobalTables'
               - 'dynamodb:DescribeGlobalTable'
               - 'dynamodb:ListTagsOfResource'
-              - 'ec2:DescribeVolumesModifications'
-              - 'ec2:DescribeVolumes'
-              - 'ec2:DescribeVolumeStatus'
-              - 'ec2:DescribeVolumeAttribute'
-              - 'ec2:DescribeInstanceStatus'
-              - 'ec2:DescribeInstances'
               - 'ecs:ListServices'
               - 'ecs:DescribeServices'
               - 'ecs:DescribeClusters'
-              - 'ecs:ListClusters'
               - 'ecs:ListTagsForResource'
               - 'ecs:ListContainerInstances'
               - 'ecs:DescribeContainerInstances'
@@ -143,47 +111,31 @@ Resources:
               - 'elasticfilesystem:DescribeFileSystems'
               - 'elasticache:DescribeCacheClusters'
               - 'elasticache:ListTagsForResource'
-              - 'es:ListDomainNames'
+              - 'elasticloadbalancing:DescribeTags'
               - 'es:DescribeElasticsearchDomain'
               - 'es:DescribeElasticsearchDomains'
               - 'es:ListTags'
               - 'elasticbeanstalk:DescribeEnvironments'
               - 'elasticbeanstalk:DescribeInstancesHealth'
               - 'elasticbeanstalk:DescribeConfigurationSettings'
-              - 'elasticloadbalancing:DescribeLoadBalancers'
               - 'elasticmapreduce:ListInstances'
-              - 'elasticmapreduce:ListClusters'
               - 'elasticmapreduce:DescribeCluster'
               - 'elasticmapreduce:ListInstanceGroups'
               - 'elasticmapreduce:ListInstanceFleets'
               - 'health:DescribeAffectedEntities'
               - 'health:DescribeEventDetails'
-              - 'health:DescribeEvents'
-              - 'iam:ListSAMLProviders'
-              - 'iam:ListOpenIDConnectProviders'
-              - 'iam:ListServerCertificates'
-              - 'iam:GetAccountAuthorizationDetails'
-              - 'iam:ListVirtualMFADevices'
-              - 'iam:GetAccountSummary'
-              - 'iot:ListTopicRules'
               - 'iot:GetTopicRule'
-              - 'iot:ListThings'
               - 'firehose:DescribeDeliveryStream'
-              - 'firehose:ListDeliveryStreams'
-              - 'kinesis:ListStreams'
               - 'kinesis:DescribeStream'
               - 'kinesis:ListTagsForStream'
               - 'rds:ListTagsForResource'
               - 'rds:DescribeDBInstances'
               - 'rds:DescribeDBClusters'
-              - 'route53:ListHealthChecks'
               - 'route53:GetHostedZone'
-              - 'route53:ListHostedZones'
               - 'route53:ListResourceRecordSets'
               - 'route53:ListTagsForResources'
               - 's3:GetLifecycleConfiguration'
               - 's3:GetBucketTagging'
-              - 's3:ListAllMyBuckets'
               - 's3:GetBucketWebsite'
               - 's3:GetBucketLogging'
               - 's3:GetBucketCORS'
@@ -200,6 +152,124 @@ Resources:
               - 's3:GetEncryptionConfiguration'
               - 's3:GetInventoryConfiguration'
               - 's3:GetIpConfiguration'
+              - 'sns:GetTopicAttributes'
+              - 'sqs:ListQueueTags'
+              - 'sqs:GetQueueAttributes'
+              - 'redshift:DescribeClusterParameters'
+              - 'lambda:ListAliases'
+              - 'lambda:ListTags'
+              - 'xray:GetGroup'
+            Resource: 
+              - !Sub 'arn:${AWS::Partition}:execute-api:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:budgets:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:elasticloadbalancing:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:cloudfront:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:dynamodb:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:dynamodb::${AWS::AccountId}:*' #global table 
+              - !Sub 'arn:${AWS::Partition}:ecs:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:elasticfilesystem:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:elasticache:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:es:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:elasticbeanstalk:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:elasticmapreduce:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:health:*::*'
+              - !Sub 'arn:${AWS::Partition}:iot:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:firehose:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:kinesis:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:rds:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:route53:::*'
+              - !Sub 'arn:${AWS::Partition}:s3:::*'
+              - !Sub 'arn:${AWS::Partition}:sns:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:sqs:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:redshift:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:xray:*:${AWS::AccountId}:*'
+  NewRelicCustomPolicyGeneric:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: F5
+            reason: 'AWS does not support resource ARNs in the resource element of IAM policy statements. For AWS support, add “Resource”: “*” to your policy.'
+          - id: W13
+            reason: "New Relic requires permission to read telemetry data from all AWS resources in your account."
+          - id: W28
+            reason: "New Relic must use unique IAM role names to identify them."
+      cfn-lint:
+        config:
+          ignore_checks:
+            - EIAMPolicyWildcardResource #see Sid Integration2 under policy document
+    Condition: UseCustomPolicy
+    Properties:    
+      ManagedPolicyName: !Join ['-', [!Ref PolicyName, 'GenericResources']]
+      Roles:
+        - !Ref NewRelicCustomPolicyRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: Integration2 # These permissions does not support specifying a resource ARN in the Resource element of an IAM policy statement, exception for EIAMPolicyWildcardResource
+            Effect: Allow
+            Action:    
+              - 'tag:GetResources'
+              - 'support:DescribeTrustedAdvisorCheckRefreshStatuses'
+              - 'support:DescribeTrustedAdvisorCheckResult'
+              - 'support:DescribeTrustedAdvisorChecks'
+              - 'support:DescribeTrustedAdvisorCheckSummaries'
+              - 'support:RefreshTrustedAdvisorCheck'
+              - 'trustedadvisor:DescribeNotificationPreferences'
+              - 'trustedadvisor:DescribeReports'
+              - 'trustedadvisor:DescribeServiceMetadata'
+              - 'trustedadvisor:DescribeAccountAccess'
+              - 'trustedadvisor:DescribeCheckRefreshStatuses'
+              - 'trustedadvisor:DescribeCheckItems'
+              - 'trustedadvisor:DescribeAccount'
+              - 'trustedadvisor:DescribeOrganization'
+              - 'trustedadvisor:DescribeOrganizationAccounts'
+              - 'trustedadvisor:DescribeCheckSummaries'
+              - 'trustedadvisor:DescribeChecks'
+              - 's3:ListAllMyBuckets'
+              - 'elasticloadbalancing:DescribeLoadBalancers'
+              - 'elasticloadbalancing:DescribeTargetGroups'
+              - 'elasticloadbalancing:DescribeLoadBalancerAttributes'
+              - 'elasticloadbalancing:DescribeListeners'
+              - 'elasticloadbalancing:DescribeRules'
+              - 'elasticloadbalancing:DescribeTargetGroupAttributes'              
+              - 'elasticloadbalancing:DescribeInstanceHealth'              
+              - 'elasticloadbalancing:DescribeLoadBalancerPolicies'
+              - 'elasticloadbalancing:DescribeLoadBalancerPolicyTypes'
+              - 'autoscaling:DescribeLaunchConfigurations'
+              - 'autoscaling:DescribeAutoScalingGroups'
+              - 'autoscaling:DescribePolicies'
+              - 'autoscaling:DescribeTags'
+              - 'autoscaling:DescribeAccountLimits'
+              - 'cloudfront:ListDistributions'
+              - 'cloudfront:ListStreamingDistributions'
+              - 'cloudtrail:LookupEvents'
+              - 'dynamodb:DescribeLimits'
+              - 'dynamodb:ListTables'
+              - 'dynamodb:ListGlobalTables'
+              - 'ec2:DescribeVolumesModifications'
+              - 'ec2:DescribeVolumes'
+              - 'ec2:DescribeVolumeStatus'
+              - 'ec2:DescribeVolumeAttribute'
+              - 'ec2:DescribeInstanceStatus'
+              - 'ec2:DescribeInstances'
+              - 'ecs:ListClusters'
+              - 'es:ListDomainNames'
+              - 'elasticmapreduce:ListClusters'
+              - 'health:DescribeEvents'
+              - 'iam:ListSAMLProviders'
+              - 'iam:ListOpenIDConnectProviders'
+              - 'iam:ListServerCertificates'
+              - 'iam:GetAccountAuthorizationDetails'
+              - 'iam:ListVirtualMFADevices'
+              - 'iam:GetAccountSummary'
+              - 'iot:ListTopicRules'
+              - 'iot:ListThings'
+              - 'firehose:ListDeliveryStreams'
+              - 'kinesis:ListStreams'
+              - 'route53:ListHealthChecks'
+              - 'route53:ListHostedZones'
               - 'ses:ListConfigurationSets'
               - 'ses:GetSendQuota'
               - 'ses:DescribeConfigurationSet'
@@ -207,12 +277,8 @@ Resources:
               - 'ses:ListReceiptRuleSets'
               - 'ses:DescribeReceiptRule'
               - 'ses:DescribeReceiptRuleSet'
-              - 'sns:GetTopicAttributes'
               - 'sns:ListTopics'
               - 'sqs:ListQueues'
-              - 'sqs:ListQueueTags'
-              - 'sqs:GetQueueAttributes'
-              - 'tag:GetResources'
               - 'ec2:DescribeInternetGateways'
               - 'ec2:DescribeVpcs'
               - 'ec2:DescribeNatGateways'
@@ -226,16 +292,12 @@ Resources:
               - 'ec2:DescribeNetworkInterfaces'
               - 'ec2:DescribeVpnConnections'
               - 'redshift:DescribeClusters'
-              - 'redshift:DescribeClusterParameters'
               - 'lambda:GetAccountSettings'
               - 'lambda:ListFunctions'
-              - 'lambda:ListAliases'
-              - 'lambda:ListTags'
               - 'lambda:ListEventSourceMappings'
               - 'cloudwatch:GetMetricStatistics'
               - 'cloudwatch:ListMetrics'
               - 'cloudwatch:GetMetricData'
-              - 'support:*'
               - 'xray:BatchGetTraces'
               - 'xray:GetInsightSummaries'
               - 'xray:GetServiceGraph'
@@ -248,7 +310,6 @@ Resources:
               - 'xray:GetEncryptionConfig'
               - 'xray:GetSamplingTargets'
               - 'xray:GetTimeSeriesServiceStatistics'
-              - 'xray:GetGroup'
               - 'xray:GetInsight'
               - 'xray:GetInsightEvents'
             Resource: '*'

--- a/templates/newrelic-stack-set.yml
+++ b/templates/newrelic-stack-set.yml
@@ -161,6 +161,7 @@ Resources:
               - 'xray:GetGroup'
             Resource: 
               - !Sub 'arn:${AWS::Partition}:execute-api:*:${AWS::AccountId}:*'
+              - !Sub 'arn:${AWS::Partition}:apigateway:*::*'
               - !Sub 'arn:${AWS::Partition}:budgets:*:${AWS::AccountId}:*'
               - !Sub 'arn:${AWS::Partition}:elasticloadbalancing:*:${AWS::AccountId}:*'
               - !Sub 'arn:${AWS::Partition}:cloudfront:*:${AWS::AccountId}:*'

--- a/templates/newrelic-stack-set.yml
+++ b/templates/newrelic-stack-set.yml
@@ -16,6 +16,10 @@ Parameters:
     is created using the name you specify. This custom policy includes only minimal permissions 
     that allow New Relic to monitor your Lambda functions. Note that you are responsible for 
     managing a custom policy.'
+  NewRelicTrustedPrincipal:
+    Type: String
+    Default: 754728514883
+    Description: 'New Relic AWS Account Id for integration with customer AWS account. https://docs.newrelic.com/docs/integrations/amazon-integrations/get-started/connect-aws-new-relic-infrastructure-monitoring/'
 
 Conditions: 
   UseCustomPolicy: !Not [!Equals [ !Ref PolicyName, '']]
@@ -32,14 +36,14 @@ Resources:
     Condition: UseDefaultPolicy
     Properties:
       ManagedPolicyArns: 
-        - arn:aws:iam::aws:policy/ReadOnlyAccess
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/ReadOnlyAccess'
       RoleName: !Join ['_', ['NewRelicIntegrationRole', !Ref NewRelicAccountNumber]]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
           - Effect: Allow
             Principal:
-              AWS: 'arn:aws:iam::754728514883:root'
+              AWS: !Sub 'arn:aws:iam::${NewRelicTrustedPrincipal}:root'
             Action: 'sts:AssumeRole'
             Condition:
               StringEquals:
@@ -60,7 +64,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: 'arn:aws:iam::754728514883:root'
+              AWS: !Sub 'arn:aws:iam::${NewRelicTrustedPrincipal}:root'
             Action: 'sts:AssumeRole'
             Condition:
               StringEquals:

--- a/templates/newrelic-stack-set.yml
+++ b/templates/newrelic-stack-set.yml
@@ -69,7 +69,8 @@ Resources:
             Condition:
               StringEquals:
                 'sts:ExternalId': !Ref NewRelicAccountNumber
-                
+
+# Policy reference from: https://docs.newrelic.com/docs/integrations/amazon-integrations/get-started/integrations-managed-policies/#list-permissions                
   NewRelicCustomPolicy:
     Type: 'AWS::IAM::ManagedPolicy'
     Metadata:
@@ -81,6 +82,11 @@ Resources:
             reason: "New Relic requires permission to read telemetry data from all AWS resources in your account."
           - id: W28
             reason: "New Relic must use unique IAM role names to identify them."
+#      cfn-lint:
+#        config:
+#          ignore_checks:
+            # TrustedAdvisor access at the moment requires permission wildcard `support:*`
+            #- EIAMPolicyActionWildcard
     Condition: UseCustomPolicy
     Properties:    
       ManagedPolicyName: !Ref PolicyName
@@ -91,20 +97,39 @@ Resources:
         Statement:
           - Effect: Allow
             Action:      
-              - 'elasticloadbalancing:Describe*'
+              - 'elasticloadbalancing:DescribeLoadBalancers'
+              - 'elasticloadbalancing:DescribeTargetGroups'
+              - 'elasticloadbalancing:DescribeTags'
+              - 'elasticloadbalancing:DescribeLoadBalancerAttributes'
+              - 'elasticloadbalancing:DescribeListeners'              
+              - 'elasticloadbalancing:DescribeRules'
+              - 'elasticloadbalancing:DescribeTargetGroupAttributes'              
+              - 'elasticloadbalancing:DescribeInstanceHealth'              
+              - 'elasticloadbalancing:DescribeLoadBalancerPolicies'
+              - 'elasticloadbalancing:DescribeLoadBalancerPolicyTypes'
               - 'apigateway:GET'
               - 'apigateway:HEAD'
               - 'apigateway:OPTIONS'
-              - 'autoscaling:Describe*'
+              - 'autoscaling:DescribeLaunchConfigurations'
+              - 'autoscaling:DescribeAutoScalingGroups'
+              - 'autoscaling:DescribePolicies'
+              - 'autoscaling:DescribeTags'
+              - 'autoscaling:DescribeAccountLimits'
               - 'budgets:ViewBudget'
-              - 'cloudfront:List*Distributions'
+              - 'cloudfront:ListDistributions'
+              - 'cloudfront:ListStreamingDistributions'
               - 'cloudfront:ListTagsForResource'
               - 'cloudtrail:LookupEvents'
               - 'dynamodb:DescribeLimits'
-              - 'dynamodb:List*Tables'
-              - 'dynamodb:Describe*Table'
+              - 'dynamodb:ListTables'
+              - 'dynamodb:DescribeTable'
+              - 'dynamodb:ListGlobalTables'
+              - 'dynamodb:DescribeGlobalTable'
               - 'dynamodb:ListTagsOfResource'
-              - 'ec2:DescribeVolume*'
+              - 'ec2:DescribeVolumesModifications'
+              - 'ec2:DescribeVolumes'
+              - 'ec2:DescribeVolumeStatus'
+              - 'ec2:DescribeVolumeAttribute'
               - 'ec2:DescribeInstanceStatus'
               - 'ec2:DescribeInstances'
               - 'ecs:ListServices'
@@ -112,20 +137,25 @@ Resources:
               - 'ecs:DescribeClusters'
               - 'ecs:ListClusters'
               - 'ecs:ListTagsForResource'
+              - 'ecs:ListContainerInstances'
+              - 'ecs:DescribeContainerInstances'
               - 'elasticfilesystem:DescribeMountTargets'
               - 'elasticfilesystem:DescribeFileSystems'
               - 'elasticache:DescribeCacheClusters'
               - 'elasticache:ListTagsForResource'
               - 'es:ListDomainNames'
-              - 'es:DescribeElasticsearchDomain*'
+              - 'es:DescribeElasticsearchDomain'
+              - 'es:DescribeElasticsearchDomains'
               - 'es:ListTags'
               - 'elasticbeanstalk:DescribeEnvironments'
               - 'elasticbeanstalk:DescribeInstancesHealth'
               - 'elasticbeanstalk:DescribeConfigurationSettings'
+              - 'elasticloadbalancing:DescribeLoadBalancers'
               - 'elasticmapreduce:ListInstances'
               - 'elasticmapreduce:ListClusters'
               - 'elasticmapreduce:DescribeCluster'
               - 'elasticmapreduce:ListInstanceGroups'
+              - 'elasticmapreduce:ListInstanceFleets'
               - 'health:DescribeAffectedEntities'
               - 'health:DescribeEventDetails'
               - 'health:DescribeEvents'
@@ -206,6 +236,19 @@ Resources:
               - 'cloudwatch:ListMetrics'
               - 'cloudwatch:GetMetricData'
               - 'support:*'
-              - 'xray:BatchGet*'
-              - 'xray:Get*'
+              - 'xray:BatchGetTraces'
+              - 'xray:GetInsightSummaries'
+              - 'xray:GetServiceGraph'
+              - 'xray:GetInsightImpactGraph'
+              - 'xray:GetTraceSummaries'
+              - 'xray:GetGroups'
+              - 'xray:GetSamplingStatisticSummaries'
+              - 'xray:GetTraceGraph'
+              - 'xray:GetSamplingRules'
+              - 'xray:GetEncryptionConfig'
+              - 'xray:GetSamplingTargets'
+              - 'xray:GetTimeSeriesServiceStatistics'
+              - 'xray:GetGroup'
+              - 'xray:GetInsight'
+              - 'xray:GetInsightEvents'
             Resource: '*'


### PR DESCRIPTION
*Issue #, if available:*

* Typo in CloudWatch rules for lifecycle event

* Existing IAM managed policy does not utilize granular resource permissions.

*Description of changes:*

* Fix typo in CloudWatch rules filter for CT LifeCycle event

* Add granular resource and permission based on: https://docs.newrelic.com/docs/integrations/amazon-integrations/get-started/integrations-managed-policies/#all-permissions

* Add cfn-lint metadata for exception on permissions that does not support specifying resource ARN

* remove Python ver dependency from the Makefile

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
